### PR TITLE
feat: add configurable language and task settings to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,23 @@ Configuration is stored in `~/.config/mysuperwhisper/config.json`:
 ```json
 {
     "model_size": "medium",
-    "input_device_name": "Your Microphone",
-    "output_device_name": "Your Speakers",
+    "language": "en",
+    "task": "transcribe",
+    "input_device": "Your Microphone",
+    "output_device": "Your Speakers",
     "system_notifications_enabled": true,
     "sound_notifications_enabled": true
 }
 ```
+
+### Configuration Options
+
+- **model_size**: Size of Whisper model (see Model Sizes table below)
+- **language**: Language code for transcription (`"en"`, `"fr"`, `"es"`, etc.) or `null` for auto-detection
+- **task**: Either `"transcribe"` (default) or `"translate"` (translates audio to English)
+- **input_device** / **output_device**: Audio device names (set via tray menu)
+- **system_notifications_enabled**: Show desktop notifications
+- **sound_notifications_enabled**: Play audio beeps
 
 ### Model Sizes
 

--- a/mysuperwhisper/config.py
+++ b/mysuperwhisper/config.py
@@ -64,6 +64,8 @@ class Config:
     def __init__(self):
         # Default values
         self.model_size = "medium"
+        self.language = None  # Auto-detect if None, or use language code like "en", "fr", "es"
+        self.task = "transcribe"  # "transcribe" or "translate"
         self.system_notifications_enabled = True
         self.sound_notifications_enabled = True
         self.input_device = None
@@ -71,26 +73,46 @@ class Config:
 
     def load(self):
         """Load configuration from file."""
+        needs_save = False
         try:
             if CONFIG_FILE.exists():
                 with open(CONFIG_FILE, 'r') as f:
                     data = json.load(f)
 
                 self.model_size = data.get("model_size", "medium")
+                self.language = data.get("language")  # None = auto-detect
+                self.task = data.get("task", "transcribe")
                 self.system_notifications_enabled = data.get("system_notifications_enabled", True)
                 self.sound_notifications_enabled = data.get("sound_notifications_enabled", True)
                 self.input_device = data.get("input_device")
                 self.output_device = data.get("output_device")
 
                 log(f"Configuration loaded from {CONFIG_FILE}")
+                if self.language:
+                    log(f"Language set to: {self.language}")
+
+                # Check if new fields are missing (for config migration)
+                if "language" not in data or "task" not in data:
+                    log("Updating config file with new fields")
+                    needs_save = True
+            else:
+                log(f"No config file found at {CONFIG_FILE}, creating with defaults")
+                needs_save = True
         except Exception as e:
             log(f"Error loading config: {e}", "error")
+            needs_save = True
+
+        # Save config if needed (first run or migration)
+        if needs_save:
+            self.save()
 
     def save(self):
         """Save configuration to file."""
         try:
             data = {
                 "model_size": self.model_size,
+                "language": self.language,
+                "task": self.task,
                 "system_notifications_enabled": self.system_notifications_enabled,
                 "sound_notifications_enabled": self.sound_notifications_enabled,
                 "input_device": self.input_device,

--- a/mysuperwhisper/main.py
+++ b/mysuperwhisper/main.py
@@ -131,7 +131,7 @@ def audio_processing_loop():
 
         try:
             # Transcribe
-            text = transcription.transcribe(audio_16k, language="fr")
+            text = transcription.transcribe(audio_16k, language=config.language, task=config.task)
 
             if text:
                 log(f"Raw transcription: '{text}'")

--- a/mysuperwhisper/transcription.py
+++ b/mysuperwhisper/transcription.py
@@ -100,13 +100,14 @@ def reload_model(new_model_size):
         return False
 
 
-def transcribe(audio_data, language="fr"):
+def transcribe(audio_data, language=None, task="transcribe"):
     """
     Transcribe audio to text.
 
     Args:
         audio_data: Audio data at 16kHz (use audio.prepare_for_whisper first)
-        language: Language code ('fr', 'en', 'es', etc.)
+        language: Language code ('en', 'fr', 'es', etc.) or None for auto-detect
+        task: "transcribe" or "translate" (translate converts to English)
 
     Returns:
         str: Transcribed text, or empty string if nothing detected
@@ -117,7 +118,7 @@ def transcribe(audio_data, language="fr"):
 
     try:
         # Faster-Whisper returns a generator of segments
-        segments, info = _model.transcribe(audio_data, beam_size=5, language=language)
+        segments, info = _model.transcribe(audio_data, beam_size=5, language=language, task=task)
 
         # Reconstruct full text
         full_text = []


### PR DESCRIPTION
## Summary
This PR adds configurable language and task settings to MySuperWhisper, allowing users to force specific transcription languages or enable auto-detection instead of the hardcoded French default.

## Problem
Currently, MySuperWhisper has the language hardcoded to French (`language="fr"`) in the transcription call. Users who want to transcribe in other languages (like English) cannot change this setting, even if they manually edit the config file, because the Config class doesn't support the `language` field.

## Solution
- Added `language` and `task` fields to the `Config` class
- `language` can be set to a specific language code (`"en"`, `"fr"`, `"es"`, etc.) or `null` for auto-detection
- `task` can be `"transcribe"` (default) or `"translate"` (translates audio to English)
- Config file is now auto-generated on first run with all fields
- Removed hardcoded `"fr"` default from transcription
- Updated README.md with documentation for the new configuration options

## Changes
- **mysuperwhisper/config.py**: Added language/task fields to Config class, load/save methods, and auto-save on first run
- **mysuperwhisper/transcription.py**: Updated `transcribe()` function to accept language and task parameters
- **mysuperwhisper/main.py**: Changed to use `config.language` and `config.task` instead of hardcoded values
- **README.md**: Documented new configuration options

## Testing
Tested with:
- English language setting (`"language": "en"`) - successfully transcribes English speech
- Auto-detect mode (`"language": null`) - successfully auto-detects language
- Config file creation on first run
- Config migration for existing installations

## Example Configuration
\`\`\`json
{
    "model_size": "medium",
    "language": "en",
    "task": "transcribe",
    "system_notifications_enabled": true,
    "sound_notifications_enabled": true
}
\`\`\`